### PR TITLE
fix minDate, maxDate, minTime, maxTime for android

### DIFF
--- a/datePicker.js
+++ b/datePicker.js
@@ -209,10 +209,38 @@ class DatePicker extends Component {
       options.hour = moment(date).hour();
       options.minute = moment(date).minute();
       options.second = moment(date).second();
+
+      if (options.minTime) {
+        options = {
+          ...options,
+          minTime: moment(options.minTime).format('HH:mm:ss')
+        }
+      }
+
+      if (options.maxTime) {
+        options = {
+          ...options,
+          maxTime: moment(options.maxTime).format('HH:mm:ss')
+        }
+      }
     } else {
       options.year = moment(date).get("year");
       options.month = moment(date).get("month");
       options.day = moment(date).get("date");
+
+      if (options.minDate) {
+        options = {
+          ...options,
+          minDate: moment(options.minDate).format('DD-MM-YYYY')
+        }
+      }
+
+      if (options.maxDate) {
+        options = {
+          ...options,
+          maxDate: moment(options.maxDate).format('DD-MM-YYYY')
+        }
+      }
     }
     // console.log({ options });
     if (options.mode == "time")


### PR DESCRIPTION
Hi, i found issue on android.
minDate and minTime not working correcly, and i guess maxDate and minTime also hava same issue.

I add few code to fix it, i parse date and time to string format, that android can accept it. because in native it accept format ('DD-MM-YYYY') and ('HH:mm:ss'). So i parse date and time to correct date and time format like native android needs.

Please take a look, and test it.

Thank you.