### PR TITLE
Homepage value in podspec

### DIFF
--- a/ios/RNNavybitsDateTimePicker.podspec
+++ b/ios/RNNavybitsDateTimePicker.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNNavybitsDateTimePicker
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/HananeAlSamrout/react-native-navybits-date-time-picker"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
fixes the
```
The `RNNavybitsDateTimePicker` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```
on `pod install`
Note: this only fixes the error and not the other 2 warnings.